### PR TITLE
Add predefined filetypes for Groovy, Java and JSP.

### DIFF
--- a/filetypes.go
+++ b/filetypes.go
@@ -33,6 +33,18 @@ func init() {
 			Name:     "html",
 			Patterns: []string{"*.htm", "*.html", "*.shtml", "*.xhtml"},
 		},
+		"groovy": FileType{
+			Name:     "groovy",
+			Patterns: []string{"*.groovy", "*.gtmpl", "*.gpp", "*.grunit", "*.gradle"},
+		},
+		"java": FileType{
+			Name:     "java",
+			Patterns: []string{"*.java", "*.properties"},
+		},
+		"jsp": FileType{
+			Name:     "jsp",
+			Patterns: []string{"*.jsp", "*.jspx", "*.jhtm", "*.jhtml"},
+		},
 		"perl": FileType{
 			Name:         "perl",
 			Patterns:     []string{"*.pl", "*.pm", "*.pod", "*.t"},


### PR DESCRIPTION
Add filetypes for Groovy, Java and JSP. File type definitions swiped from Ack documentation.
