### PR TITLE
Add python file type

### DIFF
--- a/filetypes.go
+++ b/filetypes.go
@@ -64,6 +64,11 @@ func init() {
 			Patterns:     []string{"*.rb", "*.rhtml", "*.rjs", "*.rxml", "*.erb", "*.rake", "*.spec", "Rakefile"},
 			ShebangRegex: regexp.MustCompile(`^#!.*\bruby\b`),
 		},
+		"python": FileType{
+			Name:         "python",
+			Patterns:     []string{"*.py", "*.pyw", "*.pyx", "SConstruct"},
+			ShebangRegex: regexp.MustCompile(`^#!.*\bpython[0-9.]*\b`),
+		},
 		"shell": FileType{
 			Name:         "shell",
 			Patterns:     []string{"*.sh", "*.bash", "*.csh", "*.tcsh", "*.ksh", "*.zsh"},


### PR DESCRIPTION
The shebang regex was designed to match cases like:

```
#!/usr/bin/env python
#!/usr/bin/env python2
#!/usr/bin/env python3.5
```
